### PR TITLE
Update crafting skill page for better organization.

### DIFF
--- a/contents/docs/skills/individual/crafting.mdx
+++ b/contents/docs/skills/individual/crafting.mdx
@@ -3,83 +3,95 @@ title: Crafting
 lastVerified: 2025-08-16
 ---
 
-<div className="flex items-start gap-6 mb-8">
+<div className="mb-8 flex items-start gap-6">
   <div className="flex-shrink-0">
-    <img src="/assets/icons/crafting.png" alt="Crafting" className="w-24 h-24 border rounded-lg" />
+    <img
+      src="/assets/icons/crafting.png"
+      alt="Crafting"
+      className="h-24 w-24 rounded-lg border"
+    />
   </div>
   <div className="flex-1">
     <div className="space-y-2">
-      <p className="text-lg text-muted-foreground">Combine materials and components to create advanced tools, weapons, and equipment.</p>
+      <p className="text-muted-foreground text-lg">
+        Combine materials and components to create advanced tools, weapons, and
+        equipment.
+      </p>
       <div className="flex flex-wrap gap-4 text-sm">
-        <span className="px-2 py-1 bg-green-100 dark:bg-green-900 rounded-md">
+        <span className="rounded-md bg-green-100 px-2 py-1 dark:bg-green-900">
           **Type:** Skill
         </span>
-        <span className="px-2 py-1 bg-purple-100 dark:bg-purple-900 rounded-md">
-      **Max Level:** 100
-    </span>
+        <span className="rounded-md bg-purple-100 px-2 py-1 dark:bg-purple-900">
+          **Max Level:** 100
+        </span>
       </div>
     </div>
   </div>
 </div>
 
-## Resources Available by Level
+## Armor Available by Level
 
-| Level | Resource                                                                       | XP    | Steps | Required Materials |
-| ----- | ------------------------------------------------------------------------------ | ----- | ----- | ------------------ |
-| 0     | [Copper Helm](/docs/items/individual/copper_helm)                             | 200   | 500   | 10x [Copper Bar](/docs/resources/individual/copper_bar) |
-| 1     | [Copper Chest](/docs/items/individual/copper_chest)                           | 200   | 500   | 10x [Copper Bar](/docs/resources/individual/copper_bar) |
-| 2     | [Copper Legs](/docs/items/individual/copper_legs)                             | 220   | 550   | 10x [Copper Bar](/docs/resources/individual/copper_bar) |
-| 4     | [Copper Boots](/docs/items/individual/copper_boots)                           | 240   | 600   | 10x [Copper Bar](/docs/resources/individual/copper_bar) |
-| 6     | [Copper Gloves](/docs/items/individual/copper_gloves)                         | 260   | 650   | 10x [Copper Bar](/docs/resources/individual/copper_bar) |
-| 8     | [Copper Pickaxe](/docs/items/individual/copper_pickaxe)                       | 280   | 700   | 1x [Copper Toolhead](/docs/resources/individual/copper_toolhead), 1x [Birch Handle](/docs/resources/individual/birch_handle) |
-| 9     | [Copper Axe](/docs/items/individual/copper_axe)                               | 290   | 725   | 1x [Copper Toolhead](/docs/resources/individual/copper_toolhead), 1x [Birch Handle](/docs/resources/individual/birch_handle) |
-| 10    | [Copper Sickle](/docs/items/individual/copper_sickle)                         | 300   | 750   | 1x [Copper Toolhead](/docs/resources/individual/copper_toolhead), 1x [Birch Handle](/docs/resources/individual/birch_handle) |
-| 11    | [Copper Rod](/docs/items/individual/copper_rod)                               | 310   | 775   | 1x [Copper Toolhead](/docs/resources/individual/copper_toolhead), 1x [Birch Handle](/docs/resources/individual/birch_handle) |
-| 15    | [Iron Helm](/docs/items/individual/iron_helm)                                 | 400   | 750   | 10x [Iron Bar](/docs/resources/individual/iron_bar) |
-| 16    | [Iron Chest](/docs/items/individual/iron_chest)                               | 440   | 825   | 10x [Iron Bar](/docs/resources/individual/iron_bar) |
-| 17    | [Iron Legs](/docs/items/individual/iron_legs)                                 | 480   | 900   | 10x [Iron Bar](/docs/resources/individual/iron_bar) |
-| 19    | [Iron Boots](/docs/items/individual/iron_boots)                               | 520   | 975   | 10x [Iron Bar](/docs/resources/individual/iron_bar) |
-| 23    | [Iron Gloves](/docs/items/individual/iron_gloves)                             | 560   | 1050  | 10x [Iron Bar](/docs/resources/individual/iron_bar) |
-| 25    | [Iron Pickaxe](/docs/items/individual/iron_pickaxe)                           | 600   | 1125  | 1x [Iron Toolhead](/docs/resources/individual/iron_toolhead), 1x [Oak Handle](/docs/resources/individual/oak_handle) |
-| 26    | [Iron Axe](/docs/items/individual/iron_axe)                                   | 620   | 1163  | 1x [Iron Toolhead](/docs/resources/individual/iron_toolhead), 1x [Oak Handle](/docs/resources/individual/oak_handle) |
-| 27    | [Iron Sickle](/docs/items/individual/iron_sickle)                             | 640   | 1200  | 1x [Iron Toolhead](/docs/resources/individual/iron_toolhead), 1x [Oak Handle](/docs/resources/individual/oak_handle) |
-| 28    | [Iron Rod](/docs/items/individual/iron_rod)                                   | 660   | 1238  | 1x [Iron Toolhead](/docs/resources/individual/iron_toolhead), 1x [Oak Handle](/docs/resources/individual/oak_handle) |
-| 32    | [Silver Helm](/docs/items/individual/silver_helm)                             | 800   | 1000  | 10x [Silver Bar](/docs/resources/individual/silver_bar) |
-| 34    | [Silver Chest](/docs/items/individual/silver_chest)                           | 880   | 1100  | 10x [Silver Bar](/docs/resources/individual/silver_bar) |
-| 36    | [Silver Legs](/docs/items/individual/silver_legs)                             | 960   | 1200  | 10x [Silver Bar](/docs/resources/individual/silver_bar) |
-| 38    | [Silver Boots](/docs/items/individual/silver_boots)                           | 1040  | 1300  | 10x [Silver Bar](/docs/resources/individual/silver_bar) |
-| 40    | [Silver Gloves](/docs/items/individual/silver_gloves)                         | 1120  | 1400  | 10x [Silver Bar](/docs/resources/individual/silver_bar) |
-| 41    | [Silver Pickaxe](/docs/items/individual/silver_pickaxe)                       | 1200  | 1500  | 1x [Silver Toolhead](/docs/resources/individual/silver_toolhead), 1x [Pine Handle](/docs/resources/individual/pine_handle) |
-| 42    | [Silver Axe](/docs/items/individual/silver_axe)                               | 1240  | 1550  | 1x [Silver Toolhead](/docs/resources/individual/silver_toolhead), 1x [Pine Handle](/docs/resources/individual/pine_handle) |
-| 43    | [Silver Sickle](/docs/items/individual/silver_sickle)                         | 1280  | 1600  | 1x [Silver Toolhead](/docs/resources/individual/silver_toolhead), 1x [Pine Handle](/docs/resources/individual/pine_handle) |
-| 44    | [Silver Rod](/docs/items/individual/silver_rod)                               | 1320  | 1650  | 1x [Silver Toolhead](/docs/resources/individual/silver_toolhead), 1x [Pine Handle](/docs/resources/individual/pine_handle) |
-| 45    | [Gold Helm](/docs/items/individual/gold_helm)                                 | 1600  | 1250  | 10x [Gold Bar](/docs/resources/individual/gold_bar) |
-| 47    | [Gold Chest](/docs/items/individual/gold_chest)                               | 1760  | 1375  | 10x [Gold Bar](/docs/resources/individual/gold_bar) |
-| 49    | [Gold Legs](/docs/items/individual/gold_legs)                                 | 1920  | 1500  | 10x [Gold Bar](/docs/resources/individual/gold_bar) |
-| 51    | [Gold Boots](/docs/items/individual/gold_boots)                               | 2080  | 1625  | 10x [Gold Bar](/docs/resources/individual/gold_bar) |
-| 53    | [Gold Gloves](/docs/items/individual/gold_gloves)                             | 2240  | 1750  | 10x [Gold Bar](/docs/resources/individual/gold_bar) |
-| 54    | [Gold Pickaxe](/docs/items/individual/gold_pickaxe)                           | 2320  | 1813  | 1x [Gold Toolhead](/docs/resources/individual/gold_toolhead), 1x [Redwood Handle](/docs/resources/individual/redwood_handle) |
-| 55    | [Gold Axe](/docs/items/individual/gold_axe)                                   | 2400  | 1875  | 1x [Gold Toolhead](/docs/resources/individual/gold_toolhead), 1x [Redwood Handle](/docs/resources/individual/redwood_handle) |
-| 56    | [Gold Sickle](/docs/items/individual/gold_sickle)                             | 2480  | 1938  | 1x [Gold Toolhead](/docs/resources/individual/gold_toolhead), 1x [Redwood Handle](/docs/resources/individual/redwood_handle) |
-| 57    | [Gold Rod](/docs/items/individual/gold_rod)                                   | 2560  | 2000  | 1x [Gold Toolhead](/docs/resources/individual/gold_toolhead), 1x [Redwood Handle](/docs/resources/individual/redwood_handle) |
-| 60    | [Blue Helm](/docs/items/individual/blue_helm)                                 | 3200  | 1500  | 10x [Blue Bar](/docs/resources/individual/blue_bar) |
-| 62    | [Blue Chest](/docs/items/individual/blue_chest)                               | 3520  | 1650  | 10x [Blue Bar](/docs/resources/individual/blue_bar) |
-| 64    | [Blue Legs](/docs/items/individual/blue_legs)                                 | 3840  | 1800  | 10x [Blue Bar](/docs/resources/individual/blue_bar) |
-| 66    | [Blue Boots](/docs/items/individual/blue_boots)                               | 4160  | 1950  | 10x [Blue Bar](/docs/resources/individual/blue_bar) |
-| 68    | [Blue Gloves](/docs/items/individual/blue_gloves)                             | 4480  | 2100  | 10x [Blue Bar](/docs/resources/individual/blue_bar) |
-| 69    | [Blue Pickaxe](/docs/items/individual/blue_pickaxe)                           | 4640  | 2175  | 1x [Blue Toolhead](/docs/resources/individual/blue_toolhead), 1x [Silverleaf Handle](/docs/resources/individual/silverleaf_handle) |
-| 70    | [Blue Axe](/docs/items/individual/blue_axe)                                   | 4800  | 2250  | 1x [Blue Toolhead](/docs/resources/individual/blue_toolhead), 1x [Silverleaf Handle](/docs/resources/individual/silverleaf_handle) |
-| 71    | [Blue Sickle](/docs/items/individual/blue_sickle)                             | 4960  | 2325  | 1x [Blue Toolhead](/docs/resources/individual/blue_toolhead), 1x [Silverleaf Handle](/docs/resources/individual/silverleaf_handle) |
-| 72    | [Blue Rod](/docs/items/individual/blue_rod)                                   | 5120  | 2400  | 1x [Blue Toolhead](/docs/resources/individual/blue_toolhead), 1x [Silverleaf Handle](/docs/resources/individual/silverleaf_handle) |
-| 75    | [Red Helm](/docs/items/individual/red_helm)                                   | 6400  | 1750  | 10x [Red Bar](/docs/resources/individual/red_bar) |
-| 77    | [Red Chest](/docs/items/individual/red_chest)                                 | 7040  | 1925  | 10x [Red Bar](/docs/resources/individual/red_bar) |
-| 79    | [Red Legs](/docs/items/individual/red_legs)                                   | 7680  | 2100  | 10x [Red Bar](/docs/resources/individual/red_bar) |
-| 81    | [Red Boots](/docs/items/individual/red_boots)                                 | 8320  | 2275  | 10x [Red Bar](/docs/resources/individual/red_bar) |
-| 83    | [Red Gloves](/docs/items/individual/red_gloves)                               | 8960  | 2450  | 10x [Red Bar](/docs/resources/individual/red_bar) |
-| 84    | [Red Pickaxe](/docs/items/individual/red_pickaxe)                             | 9280  | 2538  | 1x [Red Toolhead](/docs/resources/individual/red_toolhead), 1x [Eldritchwood Handle](/docs/resources/individual/eldritchwood_handle) |
-| 85    | [Red Axe](/docs/items/individual/red_axe)                                     | 9600  | 2625  | 1x [Red Toolhead](/docs/resources/individual/red_toolhead), 1x [Eldritchwood Handle](/docs/resources/individual/eldritchwood_handle) |
-| 86    | [Red Sickle](/docs/items/individual/red_sickle)                               | 9920  | 2713  | 1x [Red Toolhead](/docs/resources/individual/red_toolhead), 1x [Eldritchwood Handle](/docs/resources/individual/eldritchwood_handle) |
-| 87    | [Red Rod](/docs/items/individual/red_rod)                                     | 10240 | 2800  | 1x [Red Toolhead](/docs/resources/individual/red_toolhead), 1x [Eldritchwood Handle](/docs/resources/individual/eldritchwood_handle) |
+| Level | Resource                                              | XP   | Steps | Required Materials                                      |
+| ----- | ----------------------------------------------------- | ---- | ----- | ------------------------------------------------------- |
+| 0     | [Copper Helm](/docs/items/individual/copper_helm)     | 200  | 500   | 10x [Copper Bar](/docs/resources/individual/copper_bar) |
+| 1     | [Copper Chest](/docs/items/individual/copper_chest)   | 200  | 500   | 10x [Copper Bar](/docs/resources/individual/copper_bar) |
+| 2     | [Copper Legs](/docs/items/individual/copper_legs)     | 220  | 550   | 10x [Copper Bar](/docs/resources/individual/copper_bar) |
+| 4     | [Copper Boots](/docs/items/individual/copper_boots)   | 240  | 600   | 10x [Copper Bar](/docs/resources/individual/copper_bar) |
+| 6     | [Copper Gloves](/docs/items/individual/copper_gloves) | 260  | 650   | 10x [Copper Bar](/docs/resources/individual/copper_bar) |
+| 15    | [Iron Helm](/docs/items/individual/iron_helm)         | 400  | 750   | 10x [Iron Bar](/docs/resources/individual/iron_bar)     |
+| 16    | [Iron Chest](/docs/items/individual/iron_chest)       | 440  | 825   | 10x [Iron Bar](/docs/resources/individual/iron_bar)     |
+| 17    | [Iron Legs](/docs/items/individual/iron_legs)         | 480  | 900   | 10x [Iron Bar](/docs/resources/individual/iron_bar)     |
+| 19    | [Iron Boots](/docs/items/individual/iron_boots)       | 520  | 975   | 10x [Iron Bar](/docs/resources/individual/iron_bar)     |
+| 23    | [Iron Gloves](/docs/items/individual/iron_gloves)     | 560  | 1050  | 10x [Iron Bar](/docs/resources/individual/iron_bar)     |
+| 32    | [Silver Helm](/docs/items/individual/silver_helm)     | 800  | 1000  | 10x [Silver Bar](/docs/resources/individual/silver_bar) |
+| 34    | [Silver Chest](/docs/items/individual/silver_chest)   | 880  | 1100  | 10x [Silver Bar](/docs/resources/individual/silver_bar) |
+| 36    | [Silver Legs](/docs/items/individual/silver_legs)     | 960  | 1200  | 10x [Silver Bar](/docs/resources/individual/silver_bar) |
+| 38    | [Silver Boots](/docs/items/individual/silver_boots)   | 1040 | 1300  | 10x [Silver Bar](/docs/resources/individual/silver_bar) |
+| 40    | [Silver Gloves](/docs/items/individual/silver_gloves) | 1120 | 1400  | 10x [Silver Bar](/docs/resources/individual/silver_bar) |
+| 45    | [Gold Helm](/docs/items/individual/gold_helm)         | 1600 | 1250  | 10x [Gold Bar](/docs/resources/individual/gold_bar)     |
+| 47    | [Gold Chest](/docs/items/individual/gold_chest)       | 1760 | 1375  | 10x [Gold Bar](/docs/resources/individual/gold_bar)     |
+| 49    | [Gold Legs](/docs/items/individual/gold_legs)         | 1920 | 1500  | 10x [Gold Bar](/docs/resources/individual/gold_bar)     |
+| 51    | [Gold Boots](/docs/items/individual/gold_boots)       | 2080 | 1625  | 10x [Gold Bar](/docs/resources/individual/gold_bar)     |
+| 53    | [Gold Gloves](/docs/items/individual/gold_gloves)     | 2240 | 1750  | 10x [Gold Bar](/docs/resources/individual/gold_bar)     |
+| 60    | [Blue Helm](/docs/items/individual/blue_helm)         | 3200 | 1500  | 10x [Blue Bar](/docs/resources/individual/blue_bar)     |
+| 62    | [Blue Chest](/docs/items/individual/blue_chest)       | 3520 | 1650  | 10x [Blue Bar](/docs/resources/individual/blue_bar)     |
+| 64    | [Blue Legs](/docs/items/individual/blue_legs)         | 3840 | 1800  | 10x [Blue Bar](/docs/resources/individual/blue_bar)     |
+| 66    | [Blue Boots](/docs/items/individual/blue_boots)       | 4160 | 1950  | 10x [Blue Bar](/docs/resources/individual/blue_bar)     |
+| 68    | [Blue Gloves](/docs/items/individual/blue_gloves)     | 4480 | 2100  | 10x [Blue Bar](/docs/resources/individual/blue_bar)     |
+| 75    | [Red Helm](/docs/items/individual/red_helm)           | 6400 | 1750  | 10x [Red Bar](/docs/resources/individual/red_bar)       |
+| 77    | [Red Chest](/docs/items/individual/red_chest)         | 7040 | 1925  | 10x [Red Bar](/docs/resources/individual/red_bar)       |
+| 79    | [Red Legs](/docs/items/individual/red_legs)           | 7680 | 2100  | 10x [Red Bar](/docs/resources/individual/red_bar)       |
+| 81    | [Red Boots](/docs/items/individual/red_boots)         | 8320 | 2275  | 10x [Red Bar](/docs/resources/individual/red_bar)       |
+| 83    | [Red Gloves](/docs/items/individual/red_gloves)       | 8960 | 2450  | 10x [Red Bar](/docs/resources/individual/red_bar)       |
+
+## Tools Available by Level
+
+| Level | Resource                                                | XP    | Steps | Required Materials                                                                                                                   |
+| ----- | ------------------------------------------------------- | ----- | ----- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| 8     | [Copper Pickaxe](/docs/items/individual/copper_pickaxe) | 280   | 700   | 1x [Copper Toolhead](/docs/resources/individual/copper_toolhead), 1x [Birch Handle](/docs/resources/individual/birch_handle)         |
+| 9     | [Copper Axe](/docs/items/individual/copper_axe)         | 290   | 725   | 1x [Copper Toolhead](/docs/resources/individual/copper_toolhead), 1x [Birch Handle](/docs/resources/individual/birch_handle)         |
+| 10    | [Copper Sickle](/docs/items/individual/copper_sickle)   | 300   | 750   | 1x [Copper Toolhead](/docs/resources/individual/copper_toolhead), 1x [Birch Handle](/docs/resources/individual/birch_handle)         |
+| 11    | [Copper Rod](/docs/items/individual/copper_rod)         | 310   | 775   | 1x [Copper Toolhead](/docs/resources/individual/copper_toolhead), 1x [Birch Handle](/docs/resources/individual/birch_handle)         |
+| 25    | [Iron Pickaxe](/docs/items/individual/iron_pickaxe)     | 600   | 1125  | 1x [Iron Toolhead](/docs/resources/individual/iron_toolhead), 1x [Oak Handle](/docs/resources/individual/oak_handle)                 |
+| 26    | [Iron Axe](/docs/items/individual/iron_axe)             | 620   | 1163  | 1x [Iron Toolhead](/docs/resources/individual/iron_toolhead), 1x [Oak Handle](/docs/resources/individual/oak_handle)                 |
+| 27    | [Iron Sickle](/docs/items/individual/iron_sickle)       | 640   | 1200  | 1x [Iron Toolhead](/docs/resources/individual/iron_toolhead), 1x [Oak Handle](/docs/resources/individual/oak_handle)                 |
+| 28    | [Iron Rod](/docs/items/individual/iron_rod)             | 660   | 1238  | 1x [Iron Toolhead](/docs/resources/individual/iron_toolhead), 1x [Oak Handle](/docs/resources/individual/oak_handle)                 |
+| 41    | [Silver Pickaxe](/docs/items/individual/silver_pickaxe) | 1200  | 1500  | 1x [Silver Toolhead](/docs/resources/individual/silver_toolhead), 1x [Pine Handle](/docs/resources/individual/pine_handle)           |
+| 42    | [Silver Axe](/docs/items/individual/silver_axe)         | 1240  | 1550  | 1x [Silver Toolhead](/docs/resources/individual/silver_toolhead), 1x [Pine Handle](/docs/resources/individual/pine_handle)           |
+| 43    | [Silver Sickle](/docs/items/individual/silver_sickle)   | 1280  | 1600  | 1x [Silver Toolhead](/docs/resources/individual/silver_toolhead), 1x [Pine Handle](/docs/resources/individual/pine_handle)           |
+| 44    | [Silver Rod](/docs/items/individual/silver_rod)         | 1320  | 1650  | 1x [Silver Toolhead](/docs/resources/individual/silver_toolhead), 1x [Pine Handle](/docs/resources/individual/pine_handle)           |
+| 54    | [Gold Pickaxe](/docs/items/individual/gold_pickaxe)     | 2320  | 1813  | 1x [Gold Toolhead](/docs/resources/individual/gold_toolhead), 1x [Redwood Handle](/docs/resources/individual/redwood_handle)         |
+| 55    | [Gold Axe](/docs/items/individual/gold_axe)             | 2400  | 1875  | 1x [Gold Toolhead](/docs/resources/individual/gold_toolhead), 1x [Redwood Handle](/docs/resources/individual/redwood_handle)         |
+| 56    | [Gold Sickle](/docs/items/individual/gold_sickle)       | 2480  | 1938  | 1x [Gold Toolhead](/docs/resources/individual/gold_toolhead), 1x [Redwood Handle](/docs/resources/individual/redwood_handle)         |
+| 57    | [Gold Rod](/docs/items/individual/gold_rod)             | 2560  | 2000  | 1x [Gold Toolhead](/docs/resources/individual/gold_toolhead), 1x [Redwood Handle](/docs/resources/individual/redwood_handle)         |
+| 69    | [Blue Pickaxe](/docs/items/individual/blue_pickaxe)     | 4640  | 2175  | 1x [Blue Toolhead](/docs/resources/individual/blue_toolhead), 1x [Silverleaf Handle](/docs/resources/individual/silverleaf_handle)   |
+| 70    | [Blue Axe](/docs/items/individual/blue_axe)             | 4800  | 2250  | 1x [Blue Toolhead](/docs/resources/individual/blue_toolhead), 1x [Silverleaf Handle](/docs/resources/individual/silverleaf_handle)   |
+| 71    | [Blue Sickle](/docs/items/individual/blue_sickle)       | 4960  | 2325  | 1x [Blue Toolhead](/docs/resources/individual/blue_toolhead), 1x [Silverleaf Handle](/docs/resources/individual/silverleaf_handle)   |
+| 72    | [Blue Rod](/docs/items/individual/blue_rod)             | 5120  | 2400  | 1x [Blue Toolhead](/docs/resources/individual/blue_toolhead), 1x [Silverleaf Handle](/docs/resources/individual/silverleaf_handle)   |
+| 84    | [Red Pickaxe](/docs/items/individual/red_pickaxe)       | 9280  | 2538  | 1x [Red Toolhead](/docs/resources/individual/red_toolhead), 1x [Eldritchwood Handle](/docs/resources/individual/eldritchwood_handle) |
+| 85    | [Red Axe](/docs/items/individual/red_axe)               | 9600  | 2625  | 1x [Red Toolhead](/docs/resources/individual/red_toolhead), 1x [Eldritchwood Handle](/docs/resources/individual/eldritchwood_handle) |
+| 86    | [Red Sickle](/docs/items/individual/red_sickle)         | 9920  | 2713  | 1x [Red Toolhead](/docs/resources/individual/red_toolhead), 1x [Eldritchwood Handle](/docs/resources/individual/eldritchwood_handle) |
+| 87    | [Red Rod](/docs/items/individual/red_rod)               | 10240 | 2800  | 1x [Red Toolhead](/docs/resources/individual/red_toolhead), 1x [Eldritchwood Handle](/docs/resources/individual/eldritchwood_handle) |
 
 ## Related Skills
 


### PR DESCRIPTION
## 🤝 Community Impact

How will this help other players?

This addition significantly improves the Crafting skill documentation by:
- Providing complete information about all craftable handle types and their requirements
- Helping players plan their progression path from basic Birch Handles to advanced Eldritchwood Handles
- Showing the relationship between handle tiers and the tools they're used to create
- Eliminating confusion about where to find handle crafting information
- Making the crafting guide comprehensive and self-contained for better user experience
- Following the logical progression that matches the tool crafting requirements

---

Thank you for contributing to the Stepcraft Wiki! 🎮


## 📝 Summary

Brief description of what this PR does:

- [x] Content update/correction
- [ ] New content addition
- [ ] Bug fix
- [ ] Documentation improvement
- [ ] Other: ___

## 🎯 What changed?

Reorganized the Crafting skill page to improve usability and consistency:

- Split the single large table into two organized sections: "Armor Available by Level" and "Tools Available by Level"
- Separated armor pieces (helm, chest, legs, boots, gloves) from tools (pickaxe, axe, sickle, rod)
- Maintained the same level progression and material tier organization (Copper → Iron → Silver → Gold → Blue → Red)
- Updated section headers to follow wiki conventions with "Available by Level" naming pattern
- Improved table formatting and readability

## 📖 Related Issues

- Related to improving wiki organization and user experience
- Addresses inconsistent page structure compared to other skill pages

## ✅ Checklist

Before submitting this PR, please make sure:

- [x] I have read the [contribution guidelines](CONTRIBUTING.md)
- [x] My content follows the wiki's style and formatting conventions
- [x] I have tested that my changes render correctly
- [x] I have checked for spelling and grammatical errors
- [x] My changes are accurate and well-sourced
- [x] I have added appropriate metadata (frontmatter) if creating new pages

## 🔍 Type of content

- [x] Game mechanics documentation
- [ ] Item/resource information
- [ ] Location/map content
- [x] Skill guides
- [ ] Character information
- [ ] Bug fixes or corrections

## 📸 Screenshots (if applicable)

<img width="1762" height="1155" alt="Screenshot 2025-08-17 at 5 25 39 AM" src="https://github.com/user-attachments/assets/fe240d47-113b-4e0e-9b71-58e66aa5f585" />

## 🤝 Community Impact

How will this help other players?

This reorganization makes the Crafting skill page much more user-friendly by:
- Allowing players to quickly find specific item types (armor vs tools)
- Making it easier to compare progression within each category
- Following the same organizational pattern as other skill pages for consistency
- Reducing cognitive load when scanning for specific crafting recipes
- Improving the overall browsing experience for players planning their crafting progression

---

Thank you for contributing to the Stepcraft Wiki! 🎮