### PR TITLE
Update raw resources from Crafting to Gathering and add fish gathering stats.

### DIFF
--- a/contents/docs/resources/individual/apple.mdx
+++ b/contents/docs/resources/individual/apple.mdx
@@ -27,7 +27,8 @@ lastVerified: 2025-08-15
 
 - [Crimson Garden](/docs/map/individual/crimson_garden)
 
-## Crafting
+## Gathering
+
 **Level Requirement:** — | **XP Gained:** 10 | **Steps:** 50
 
 

--- a/contents/docs/resources/individual/apricot.mdx
+++ b/contents/docs/resources/individual/apricot.mdx
@@ -27,7 +27,8 @@ lastVerified: 2025-08-15
 
 - [Verdant Isle](/docs/map/individual/verdant_isle)
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 75 | **XP Gained:** 320 | **Steps:** 175
 
 

--- a/contents/docs/resources/individual/avocado.mdx
+++ b/contents/docs/resources/individual/avocado.mdx
@@ -23,5 +23,6 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 60 | **XP Gained:** 160 | **Steps:** 150

--- a/contents/docs/resources/individual/banana.mdx
+++ b/contents/docs/resources/individual/banana.mdx
@@ -27,7 +27,8 @@ lastVerified: 2025-08-15
 
 - [Pearlsand Strand](/docs/map/individual/pearlsand_strand)
 
-## Crafting
+## Gathering
+
 **Level Requirement:** — | **XP Gained:** 10 | **Steps:** 50
 
 

--- a/contents/docs/resources/individual/bear.mdx
+++ b/contents/docs/resources/individual/bear.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 90 | **XP Gained:** 640 | **Steps:** 200
 
 

--- a/contents/docs/resources/individual/bear_hide.mdx
+++ b/contents/docs/resources/individual/bear_hide.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 90 | **XP Gained:** 640 | **Steps:** 200
 
 

--- a/contents/docs/resources/individual/beige_snapper.mdx
+++ b/contents/docs/resources/individual/beige_snapper.mdx
@@ -26,3 +26,7 @@ lastVerified: 2025-08-15
 ## Found at
 
 - [Moonmere](/docs/map/individual/moonmere)
+
+## Gathering
+
+**Level Requirement:** 15 | **XP Gained:** 20 | **Steps:** 75

--- a/contents/docs/resources/individual/birch_log.mdx
+++ b/contents/docs/resources/individual/birch_log.mdx
@@ -27,7 +27,8 @@ lastVerified: 2025-08-15
 
 - [Titan's Rest](/docs/map/individual/titans_rest)
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 15 | **XP Gained:** 20 | **Steps:** 75
 
 

--- a/contents/docs/resources/individual/bird_1.mdx
+++ b/contents/docs/resources/individual/bird_1.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** — | **XP Gained:** 10 | **Steps:** 50
 
 

--- a/contents/docs/resources/individual/bird_1_meat.mdx
+++ b/contents/docs/resources/individual/bird_1_meat.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** — | **XP Gained:** 10 | **Steps:** 50
 
 

--- a/contents/docs/resources/individual/bird_2.mdx
+++ b/contents/docs/resources/individual/bird_2.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 15 | **XP Gained:** 20 | **Steps:** 75
 
 

--- a/contents/docs/resources/individual/bird_2_meat.mdx
+++ b/contents/docs/resources/individual/bird_2_meat.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 15 | **XP Gained:** 20 | **Steps:** 75
 
 

--- a/contents/docs/resources/individual/blue_ore.mdx
+++ b/contents/docs/resources/individual/blue_ore.mdx
@@ -27,7 +27,7 @@ lastVerified: 2025-08-15
 
 - [Ironheart Cliffs](/docs/map/individual/ironheart_cliffs)
 
-## Crafting
+## Gathering
 **Level Requirement:** 75 | **XP Gained:** 320 | **Steps:** 175
 
 

--- a/contents/docs/resources/individual/blueberry.mdx
+++ b/contents/docs/resources/individual/blueberry.mdx
@@ -23,5 +23,5 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
 **Level Requirement:** 60 | **XP Gained:** 160 | **Steps:** 150

--- a/contents/docs/resources/individual/broccoli.mdx
+++ b/contents/docs/resources/individual/broccoli.mdx
@@ -23,5 +23,5 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
 **Level Requirement:** 60 | **XP Gained:** 160 | **Steps:** 150

--- a/contents/docs/resources/individual/brown_mushroom.mdx
+++ b/contents/docs/resources/individual/brown_mushroom.mdx
@@ -24,5 +24,5 @@ lastVerified: 2025-08-15
 
 - [Hollow Crown](/docs/map/individual/hollow_crown)
 
-## Crafting
+## Gathering
 **Level Requirement:** 15 | **XP Gained:** 20 | **Steps:** 75

--- a/contents/docs/resources/individual/button_mushroom.mdx
+++ b/contents/docs/resources/individual/button_mushroom.mdx
@@ -23,7 +23,7 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
 **Level Requirement:** 15 | **XP Gained:** 20 | **Steps:** 75
 
 

--- a/contents/docs/resources/individual/carrot.mdx
+++ b/contents/docs/resources/individual/carrot.mdx
@@ -23,7 +23,7 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
 **Level Requirement:** — | **XP Gained:** 10 | **Steps:** 50
 
 

--- a/contents/docs/resources/individual/catfish.mdx
+++ b/contents/docs/resources/individual/catfish.mdx
@@ -23,6 +23,10 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
+## Gathering
+
+**Level Requirement:** 0 | **XP Gained:** 10 | **Steps:** 50
+
 ## Found at
 
 - [Silverleaf Refuge](/docs/map/individual/silverleaf_refuge)

--- a/contents/docs/resources/individual/chanterelle.mdx
+++ b/contents/docs/resources/individual/chanterelle.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 45 | **XP Gained:** 80 | **Steps:** 125
 
 

--- a/contents/docs/resources/individual/cherry.mdx
+++ b/contents/docs/resources/individual/cherry.mdx
@@ -28,7 +28,7 @@ lastVerified: 2025-08-15
 - [Thornspire Ruins](/docs/map/individual/thornspire_ruins)
 - [Crimson Garden](/docs/map/individual/crimson_garden)
 
-## Crafting
+## Gathering
 **Level Requirement:** 15 | **XP Gained:** 20 | **Steps:** 75
 
 

--- a/contents/docs/resources/individual/chili_pepper.mdx
+++ b/contents/docs/resources/individual/chili_pepper.mdx
@@ -30,7 +30,7 @@ lastVerified: 2025-08-15
 - [Blooming Glade](/docs/map/individual/blooming_glade)
 - [Blooming Glade Outskirts](/docs/map/individual/blooming_glade_outskirts)
 
-## Crafting
+## Gathering
 **Level Requirement:** 30 | **XP Gained:** 40 | **Steps:** 100
 
 

--- a/contents/docs/resources/individual/chub.mdx
+++ b/contents/docs/resources/individual/chub.mdx
@@ -23,6 +23,10 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
+## Gathering
+
+**Level Requirement:** 0 | **XP Gained:** 10 | **Steps:** 50
+
 ## Found at
 
 - [Silverleaf Refuge](/docs/map/individual/silverleaf_refuge)

--- a/contents/docs/resources/individual/coconut.mdx
+++ b/contents/docs/resources/individual/coconut.mdx
@@ -27,5 +27,5 @@ lastVerified: 2025-08-15
 
 - [Pearlsand Strand](/docs/map/individual/pearlsand_strand)
 
-## Crafting
+## Gathering
 **Level Requirement:** 30 | **XP Gained:** 40 | **Steps:** 100

--- a/contents/docs/resources/individual/copper_ore.mdx
+++ b/contents/docs/resources/individual/copper_ore.mdx
@@ -29,7 +29,8 @@ lastVerified: 2025-08-15
 - [Titan's Rest Outskirts](/docs/map/individual/titans_rest_outskirts)
 - [Ironheart Cliffs](/docs/map/individual/ironheart_cliffs)
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 15 | **XP Gained:** 20 | **Steps:** 75
 
 ## Gems Found when Mining

--- a/contents/docs/resources/individual/corn.mdx
+++ b/contents/docs/resources/individual/corn.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 15 | **XP Gained:** 20 | **Steps:** 75
 
 

--- a/contents/docs/resources/individual/deer.mdx
+++ b/contents/docs/resources/individual/deer.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 67 | **XP Gained:** 240 | **Steps:** 160
 
 

--- a/contents/docs/resources/individual/deer_hide.mdx
+++ b/contents/docs/resources/individual/deer_hide.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 67 | **XP Gained:** 240 | **Steps:** 160
 
 

--- a/contents/docs/resources/individual/deer_meat.mdx
+++ b/contents/docs/resources/individual/deer_meat.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 67 | **XP Gained:** 240 | **Steps:** 160
 
 

--- a/contents/docs/resources/individual/dragon_fruit.mdx
+++ b/contents/docs/resources/individual/dragon_fruit.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 90 | **XP Gained:** 640 | **Steps:** 200
 
 

--- a/contents/docs/resources/individual/egg.mdx
+++ b/contents/docs/resources/individual/egg.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 30 | **XP Gained:** 40 | **Steps:** 100
 
 

--- a/contents/docs/resources/individual/eggplant.mdx
+++ b/contents/docs/resources/individual/eggplant.mdx
@@ -23,5 +23,6 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** — | **XP Gained:** 10 | **Steps:** 50

--- a/contents/docs/resources/individual/eldritchwood_log.mdx
+++ b/contents/docs/resources/individual/eldritchwood_log.mdx
@@ -27,7 +27,8 @@ lastVerified: 2025-08-15
 
 - [Ironheart Cliffs](/docs/map/individual/ironheart_cliffs)
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 90 | **XP Gained:** 640 | **Steps:** 200
 
 

--- a/contents/docs/resources/individual/fly_agaric.mdx
+++ b/contents/docs/resources/individual/fly_agaric.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** — | **XP Gained:** 10 | **Steps:** 50
 
 

--- a/contents/docs/resources/individual/fox.mdx
+++ b/contents/docs/resources/individual/fox.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 60 | **XP Gained:** 160 | **Steps:** 150
 
 

--- a/contents/docs/resources/individual/fox_hide.mdx
+++ b/contents/docs/resources/individual/fox_hide.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 60 | **XP Gained:** 160 | **Steps:** 150
 
 

--- a/contents/docs/resources/individual/fox_meat.mdx
+++ b/contents/docs/resources/individual/fox_meat.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 60 | **XP Gained:** 160 | **Steps:** 150
 
 

--- a/contents/docs/resources/individual/garlic.mdx
+++ b/contents/docs/resources/individual/garlic.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** — | **XP Gained:** 10 | **Steps:** 50
 
 

--- a/contents/docs/resources/individual/gold_ore.mdx
+++ b/contents/docs/resources/individual/gold_ore.mdx
@@ -27,7 +27,8 @@ lastVerified: 2025-08-15
 
 - [Ironheart Cliffs](/docs/map/individual/ironheart_cliffs)
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 60 | **XP Gained:** 160 | **Steps:** 150
 
 

--- a/contents/docs/resources/individual/grapes.mdx
+++ b/contents/docs/resources/individual/grapes.mdx
@@ -28,7 +28,8 @@ lastVerified: 2025-08-15
 - [Blooming Glade](/docs/map/individual/blooming_glade)
 - [Blooming Glade Outskirts](/docs/map/individual/blooming_glade_outskirts)
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 15 | **XP Gained:** 20 | **Steps:** 75
 
 

--- a/contents/docs/resources/individual/half_shoal.mdx
+++ b/contents/docs/resources/individual/half_shoal.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 75 | **XP Gained:** 320 | **Steps:** 175
 
 

--- a/contents/docs/resources/individual/hog.mdx
+++ b/contents/docs/resources/individual/hog.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 52 | **XP Gained:** 120 | **Steps:** 135
 
 

--- a/contents/docs/resources/individual/hog_hide.mdx
+++ b/contents/docs/resources/individual/hog_hide.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 52 | **XP Gained:** 120 | **Steps:** 135
 
 

--- a/contents/docs/resources/individual/iron_ore.mdx
+++ b/contents/docs/resources/individual/iron_ore.mdx
@@ -28,7 +28,8 @@ lastVerified: 2025-08-15
 - [Titan's Rest](/docs/map/individual/titans_rest)
 - [Ironheart Cliffs](/docs/map/individual/ironheart_cliffs)
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 30 | **XP Gained:** 40 | **Steps:** 100
 
 ## Gems Found when Mining

--- a/contents/docs/resources/individual/kiwi.mdx
+++ b/contents/docs/resources/individual/kiwi.mdx
@@ -27,7 +27,8 @@ lastVerified: 2025-08-15
 
 - [Verdant Isle](/docs/map/individual/verdant_isle)
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 60 | **XP Gained:** 160 | **Steps:** 150
 
 

--- a/contents/docs/resources/individual/lemon.mdx
+++ b/contents/docs/resources/individual/lemon.mdx
@@ -27,7 +27,8 @@ lastVerified: 2025-08-15
 
 - [Verdant Isle](/docs/map/individual/verdant_isle)
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 30 | **XP Gained:** 40 | **Steps:** 100
 
 

--- a/contents/docs/resources/individual/lettuce.mdx
+++ b/contents/docs/resources/individual/lettuce.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** — | **XP Gained:** 20 | **Steps:** 75
 
 

--- a/contents/docs/resources/individual/milk.mdx
+++ b/contents/docs/resources/individual/milk.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 60 | **XP Gained:** 160 | **Steps:** 150
 
 

--- a/contents/docs/resources/individual/moose.mdx
+++ b/contents/docs/resources/individual/moose.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 75 | **XP Gained:** 320 | **Steps:** 175
 
 

--- a/contents/docs/resources/individual/moose_hide.mdx
+++ b/contents/docs/resources/individual/moose_hide.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 75 | **XP Gained:** 320 | **Steps:** 175
 
 

--- a/contents/docs/resources/individual/morel.mdx
+++ b/contents/docs/resources/individual/morel.mdx
@@ -23,5 +23,6 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 60 | **XP Gained:** 160 | **Steps:** 150

--- a/contents/docs/resources/individual/oak_log.mdx
+++ b/contents/docs/resources/individual/oak_log.mdx
@@ -31,7 +31,8 @@ lastVerified: 2025-08-15
 - [Mycelwood Thicket](/docs/map/individual/mycelwood_thicket)
 - [Mycelwood Thicket Outskirts](/docs/map/individual/mycelwood_thicket_outskirts)
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 30 | **XP Gained:** 40 | **Steps:** 100
 
 

--- a/contents/docs/resources/individual/onion.mdx
+++ b/contents/docs/resources/individual/onion.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 30 | **XP Gained:** 40 | **Steps:** 100
 
 

--- a/contents/docs/resources/individual/orange.mdx
+++ b/contents/docs/resources/individual/orange.mdx
@@ -27,7 +27,8 @@ lastVerified: 2025-08-15
 
 - [Verdant Isle](/docs/map/individual/verdant_isle)
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 90 | **XP Gained:** 640 | **Steps:** 200
 
 

--- a/contents/docs/resources/individual/oyster.mdx
+++ b/contents/docs/resources/individual/oyster.mdx
@@ -27,7 +27,8 @@ lastVerified: 2025-08-15
 
 - [Pearlsand Strand](/docs/map/individual/pearlsand_strand)
 
-## Crafting
+## Gathering
+
 **Level Requirement:** — | **XP Gained:** 10 | **Steps:** 50
 
 

--- a/contents/docs/resources/individual/papaya.mdx
+++ b/contents/docs/resources/individual/papaya.mdx
@@ -27,7 +27,8 @@ lastVerified: 2025-08-15
 
 - [Pearlsand Strand](/docs/map/individual/pearlsand_strand)
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 75 | **XP Gained:** 320 | **Steps:** 175
 
 

--- a/contents/docs/resources/individual/parrot_waxcap.mdx
+++ b/contents/docs/resources/individual/parrot_waxcap.mdx
@@ -23,5 +23,6 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 67 | **XP Gained:** 240 | **Steps:** 160

--- a/contents/docs/resources/individual/peach_bait.mdx
+++ b/contents/docs/resources/individual/peach_bait.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 82 | **XP Gained:** 480 | **Steps:** 185
 
 

--- a/contents/docs/resources/individual/pear.mdx
+++ b/contents/docs/resources/individual/pear.mdx
@@ -27,7 +27,8 @@ lastVerified: 2025-08-15
 
 - [Verdant Isle](/docs/map/individual/verdant_isle)
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 15 | **XP Gained:** 20 | **Steps:** 75
 
 

--- a/contents/docs/resources/individual/peas.mdx
+++ b/contents/docs/resources/individual/peas.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 75 | **XP Gained:** 320 | **Steps:** 175
 
 

--- a/contents/docs/resources/individual/penny_bun.mdx
+++ b/contents/docs/resources/individual/penny_bun.mdx
@@ -23,5 +23,6 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 30 | **XP Gained:** 40 | **Steps:** 100

--- a/contents/docs/resources/individual/pine_log.mdx
+++ b/contents/docs/resources/individual/pine_log.mdx
@@ -29,7 +29,8 @@ lastVerified: 2025-08-15
 - [Mycelwood Thicket](/docs/map/individual/mycelwood_thicket)
 - [Mycelwood Thicket Outskirts](/docs/map/individual/mycelwood_thicket_outskirts)
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 45 | **XP Gained:** 80 | **Steps:** 125
 
 

--- a/contents/docs/resources/individual/pineapple.mdx
+++ b/contents/docs/resources/individual/pineapple.mdx
@@ -27,7 +27,7 @@ lastVerified: 2025-08-15
 
 - [Pearlsand Strand](/docs/map/individual/pearlsand_strand)
 
-## Crafting
+## Gathering
 **Level Requirement:** 45 | **XP Gained:** 80 | **Steps:** 125
 
 

--- a/contents/docs/resources/individual/pixies_parasol.mdx
+++ b/contents/docs/resources/individual/pixies_parasol.mdx
@@ -23,5 +23,6 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 75 | **XP Gained:** 320 | **Steps:** 175

--- a/contents/docs/resources/individual/pomegranate.mdx
+++ b/contents/docs/resources/individual/pomegranate.mdx
@@ -28,7 +28,8 @@ lastVerified: 2025-08-15
 - [Thornspire Ruins](/docs/map/individual/thornspire_ruins)
 - [Crimson Garden](/docs/map/individual/crimson_garden)
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 75 | **XP Gained:** 320 | **Steps:** 175
 
 

--- a/contents/docs/resources/individual/potato.mdx
+++ b/contents/docs/resources/individual/potato.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 37 | **XP Gained:** 60 | **Steps:** 110
 
 

--- a/contents/docs/resources/individual/puff_bait.mdx
+++ b/contents/docs/resources/individual/puff_bait.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 75 | **XP Gained:** 320 | **Steps:** 175
 
 

--- a/contents/docs/resources/individual/rabbit.mdx
+++ b/contents/docs/resources/individual/rabbit.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 45 | **XP Gained:** 80 | **Steps:** 125
 
 

--- a/contents/docs/resources/individual/rabbit_hide.mdx
+++ b/contents/docs/resources/individual/rabbit_hide.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 45 | **XP Gained:** 80 | **Steps:** 125
 
 

--- a/contents/docs/resources/individual/radish.mdx
+++ b/contents/docs/resources/individual/radish.mdx
@@ -23,5 +23,6 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 90 | **XP Gained:** 640 | **Steps:** 200

--- a/contents/docs/resources/individual/rainbow_trout.mdx
+++ b/contents/docs/resources/individual/rainbow_trout.mdx
@@ -23,6 +23,10 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
+## Gathering
+
+**Level Requirement:** 15 | **XP Gained:** 20 | **Steps:** 75
+
 ## Found at
 
 - [Crystalrun River](/docs/map/individual/crystalrun_river)

--- a/contents/docs/resources/individual/raspberry.mdx
+++ b/contents/docs/resources/individual/raspberry.mdx
@@ -30,7 +30,8 @@ lastVerified: 2025-08-15
 - [Blooming Glade](/docs/map/individual/blooming_glade)
 - [Blooming Glade Outskirts](/docs/map/individual/blooming_glade_outskirts)
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 45 | **XP Gained:** 80 | **Steps:** 125
 
 

--- a/contents/docs/resources/individual/red_ore.mdx
+++ b/contents/docs/resources/individual/red_ore.mdx
@@ -28,7 +28,8 @@ lastVerified: 2025-08-15
 - [Titan's Rest](/docs/map/individual/titans_rest)
 - [Ironheart Cliffs](/docs/map/individual/ironheart_cliffs)
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 90 | **XP Gained:** 640 | **Steps:** 200
 
 

--- a/contents/docs/resources/individual/redwood_log.mdx
+++ b/contents/docs/resources/individual/redwood_log.mdx
@@ -28,7 +28,8 @@ lastVerified: 2025-08-15
 - [Thornspire Ruins](/docs/map/individual/thornspire_ruins)
 - [Crimson Garden](/docs/map/individual/crimson_garden)
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 60 | **XP Gained:** 160 | **Steps:** 150
 
 

--- a/contents/docs/resources/individual/rice.mdx
+++ b/contents/docs/resources/individual/rice.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 15 | **XP Gained:** 20 | **Steps:** 75
 
 

--- a/contents/docs/resources/individual/salmon.mdx
+++ b/contents/docs/resources/individual/salmon.mdx
@@ -23,7 +23,9 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
+## Gathering
 
+**Level Requirement:** 0 | **XP Gained:** 10 | **Steps:** 50
 
 ## Found at
 

--- a/contents/docs/resources/individual/sardine_bait.mdx
+++ b/contents/docs/resources/individual/sardine_bait.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 15 | **XP Gained:** 20 | **Steps:** 75
 
 

--- a/contents/docs/resources/individual/shrimp_bait.mdx
+++ b/contents/docs/resources/individual/shrimp_bait.mdx
@@ -23,9 +23,9 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
-**Level Requirement:** — | **XP Gained:** 10 | **Steps:** 50
+## Gathering
 
+**Level Requirement:** 0 | **XP Gained:** 10 | **Steps:** 50
 
 **Required Materials:**
 - 2x [Shrimp](/docs/resources/individual/shrimp)

--- a/contents/docs/resources/individual/silver_ore.mdx
+++ b/contents/docs/resources/individual/silver_ore.mdx
@@ -28,7 +28,8 @@ lastVerified: 2025-08-15
 - [Ironheart Cliffs](/docs/map/individual/ironheart_cliffs)
 - [Ironheart Cliffs Outskirts](/docs/map/individual/ironheart_cliffs_outskirts)
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 45 | **XP Gained:** 80 | **Steps:** 125
 
 

--- a/contents/docs/resources/individual/silverleaf_log.mdx
+++ b/contents/docs/resources/individual/silverleaf_log.mdx
@@ -27,7 +27,8 @@ lastVerified: 2025-08-15
 
 - [Silverleaf Refuge](/docs/map/individual/silverleaf_refuge)
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 75 | **XP Gained:** 320 | **Steps:** 175
 
 

--- a/contents/docs/resources/individual/slime.mdx
+++ b/contents/docs/resources/individual/slime.mdx
@@ -20,7 +20,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** — | **XP Gained:** 10 | **Steps:** 50
 
 

--- a/contents/docs/resources/individual/spring_onion.mdx
+++ b/contents/docs/resources/individual/spring_onion.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** — | **XP Gained:** 4 | **Steps:** 10
 
 

--- a/contents/docs/resources/individual/squirrel.mdx
+++ b/contents/docs/resources/individual/squirrel.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 30 | **XP Gained:** 40 | **Steps:** 100
 
 

--- a/contents/docs/resources/individual/squirrel_hide.mdx
+++ b/contents/docs/resources/individual/squirrel_hide.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 30 | **XP Gained:** 40 | **Steps:** 100
 
 

--- a/contents/docs/resources/individual/squirrel_meat.mdx
+++ b/contents/docs/resources/individual/squirrel_meat.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 30 | **XP Gained:** 40 | **Steps:** 100
 
 

--- a/contents/docs/resources/individual/starfish.mdx
+++ b/contents/docs/resources/individual/starfish.mdx
@@ -27,5 +27,6 @@ lastVerified: 2025-08-15
 
 - [Pearlsand Strand](/docs/map/individual/pearlsand_strand)
 
-## Crafting
+## Gathering
+
 **Level Requirement:** — | **XP Gained:** 10 | **Steps:** 50

--- a/contents/docs/resources/individual/sticks.mdx
+++ b/contents/docs/resources/individual/sticks.mdx
@@ -41,7 +41,8 @@ lastVerified: 2025-08-15
 - [Blooming Glade](/docs/map/individual/blooming_glade)
 - [Blooming Glade Outskirts](/docs/map/individual/blooming_glade_outskirts)
 
-## Crafting
+## Gathering
+
 **Level Requirement:** — | **XP Gained:** 10 | **Steps:** 50
 
 

--- a/contents/docs/resources/individual/stone.mdx
+++ b/contents/docs/resources/individual/stone.mdx
@@ -28,7 +28,8 @@ lastVerified: 2025-08-15
 - [Titan's Rest](/docs/map/individual/titans_rest)
 - [Titan's Rest Outskirts](/docs/map/individual/titans_rest_outskirts)
 
-## Crafting
+## Gathering
+
 **Level Requirement:** — | **XP Gained:** 10 | **Steps:** 50
 
 

--- a/contents/docs/resources/individual/strawberry.mdx
+++ b/contents/docs/resources/individual/strawberry.mdx
@@ -30,7 +30,8 @@ lastVerified: 2025-08-15
 - [Blooming Glade](/docs/map/individual/blooming_glade)
 - [Blooming Glade Outskirts](/docs/map/individual/blooming_glade_outskirts)
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 60 | **XP Gained:** 160 | **Steps:** 150
 
 

--- a/contents/docs/resources/individual/tiger_bait.mdx
+++ b/contents/docs/resources/individual/tiger_bait.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 45 | **XP Gained:** 80 | **Steps:** 125
 
 

--- a/contents/docs/resources/individual/tilapia.mdx
+++ b/contents/docs/resources/individual/tilapia.mdx
@@ -29,6 +29,10 @@ lastVerified: 2025-08-15
 
 - [Moonmere](/docs/map/individual/moonmere)
 
+## Gathering
+
+**Level Requirement:** 0 | **XP Gained:** 10 | **Steps:** 50
+
 ## Used in Recipes
 
 This resource is used in the following crafting recipes:

--- a/contents/docs/resources/individual/tomato.mdx
+++ b/contents/docs/resources/individual/tomato.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 60 | **XP Gained:** 160 | **Steps:** 150
 
 

--- a/contents/docs/resources/individual/violet_webcap.mdx
+++ b/contents/docs/resources/individual/violet_webcap.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 90 | **XP Gained:** 640 | **Steps:** 200
 
 

--- a/contents/docs/resources/individual/voidstone.mdx
+++ b/contents/docs/resources/individual/voidstone.mdx
@@ -23,5 +23,6 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 92 | **XP Gained:** 960 | **Steps:** 225

--- a/contents/docs/resources/individual/watermelon.mdx
+++ b/contents/docs/resources/individual/watermelon.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 75 | **XP Gained:** 320 | **Steps:** 175
 
 

--- a/contents/docs/resources/individual/wheat.mdx
+++ b/contents/docs/resources/individual/wheat.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** — | **XP Gained:** 10 | **Steps:** 50
 
 

--- a/contents/docs/resources/individual/witchs_hat.mdx
+++ b/contents/docs/resources/individual/witchs_hat.mdx
@@ -23,5 +23,6 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 82 | **XP Gained:** 480 | **Steps:** 185

--- a/contents/docs/resources/individual/wolf.mdx
+++ b/contents/docs/resources/individual/wolf.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 82 | **XP Gained:** 480 | **Steps:** 185
 
 

--- a/contents/docs/resources/individual/wolf_hide.mdx
+++ b/contents/docs/resources/individual/wolf_hide.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 82 | **XP Gained:** 480 | **Steps:** 185
 
 

--- a/contents/docs/resources/individual/wolf_meat.mdx
+++ b/contents/docs/resources/individual/wolf_meat.mdx
@@ -23,7 +23,8 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 82 | **XP Gained:** 480 | **Steps:** 185
 
 

--- a/contents/docs/resources/individual/yellow_pepper.mdx
+++ b/contents/docs/resources/individual/yellow_pepper.mdx
@@ -23,5 +23,6 @@ lastVerified: 2025-08-15
   </div>
 </div>
 
-## Crafting
+## Gathering
+
 **Level Requirement:** 60 | **XP Gained:** 160 | **Steps:** 150

--- a/contents/docs/skills/individual/fishing.mdx
+++ b/contents/docs/skills/individual/fishing.mdx
@@ -24,39 +24,43 @@ lastVerified: 2025-08-16
 
 ## Resources Available by Level
 
-| Level | Resource                                                     | XP  | Steps | Used in Recipes |
-| ----- | ------------------------------------------------------------ | --- | ----- | --------------- |
-| 0     | [Starfish](/docs/resources/individual/starfish)            | 10  | 50    | — |
-| 0     | [Catfish](/docs/resources/individual/catfish)              | —   | —     | — |
-| 0     | [Salmon](/docs/resources/individual/salmon)                | —   | —     | [Sashimi](/docs/items/individual/sashimi), [Grey Fish](/docs/items/individual/grey_fish), [Blue Fish](/docs/items/individual/blue_fish) |
-| 0     | [Sardine](/docs/resources/individual/sardine)              | —   | —     | [Sardine Bait](/docs/resources/individual/sardine_bait) |
-| 15    | [Red Drum](/docs/resources/individual/red_drum)            | —   | —     | — |
-| 15    | [Rainbow Trout](/docs/resources/individual/rainbow_trout)  | —   | —     | — |
-| 15    | [Beige Snapper](/docs/resources/individual/beige_snapper)  | —   | —     | — |
-| 30    | [Crab](/docs/resources/individual/crab)                     | —   | —     | [Cooked Crab](/docs/items/individual/cooked_crab) |
-| 30    | [Carp](/docs/resources/individual/carp)                     | —   | —     | — |
-| 30    | [Grouper](/docs/resources/individual/grouper)               | —   | —     | — |
-| 45    | [Largemouth Bass](/docs/resources/individual/largemouth_bass) | —   | —     | — |
-| 45    | [Tiger Trout](/docs/resources/individual/tiger_trout)       | —   | —     | — |
-| 45    | [Red Rainbowfish](/docs/resources/individual/red_rainbowfish) | —   | —     | — |
-| 52    | [Rockfish](/docs/resources/individual/rockfish)             | —   | —     | — |
-| 60    | [Smallmouth Bass](/docs/resources/individual/smallmouth_bass) | —   | —     | — |
-| 60    | [Squid](/docs/resources/individual/squid)                   | —   | —     | — |
-| 60    | [Woodskip](/docs/resources/individual/woodskip)             | —   | —     | — |
-| 60    | [Chattahoochee Bass](/docs/resources/individual/chattahoochee_bass) | —   | —     | — |
-| 60    | [Lobster](/docs/resources/individual/lobster)               | —   | —     | [Cooked Lobster](/docs/items/individual/cooked_lobster) |
-| 75    | [Shad](/docs/resources/individual/shad)                     | —   | —     | — |
-| 75    | [Pufferfish](/docs/resources/individual/pufferfish)         | —   | —     | [Puff Bait](/docs/resources/individual/puff_bait) |
-| 75    | [Stingray](/docs/resources/individual/stingray)             | —   | —     | — |
-| 75    | [Lingcod](/docs/resources/individual/lingcod)               | —   | —     | — |
-| 82    | [Swordfish](/docs/resources/individual/swordfish)          | —   | —     | — |
-| 82    | [Scorpion Carp](/docs/resources/individual/scorpion_carp)   | —   | —     | — |
-| 82    | [Peach Jellyfish](/docs/resources/individual/peach_jellyfish) | —   | —     | [Peach Bait](/docs/resources/individual/peach_bait) |
-| 90    | [Speckled Cycloptopus](/docs/resources/individual/speckled_cycloptopus) | —   | —     | — |
-| 90    | [Green Sunfish](/docs/resources/individual/green_sunfish)   | —   | —     | — |
-| 90    | [Sea Snake](/docs/resources/individual/sea_snake)           | —   | —     | — |
-| 90    | [Orb Octopus](/docs/resources/individual/orb_octopus)       | —   | —     | — |
-| 90    | [Eldritch Bass](/docs/resources/individual/eldritch_bass)   | —   | —     | — |
+| Level | Resource                                                                | XP  | Steps | Used in Recipes                                                                                                                         |
+| ----- | ----------------------------------------------------------------------- | --- | ----- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| 0     | [Starfish](/docs/resources/individual/starfish)                         | 10  | 50    | —                                                                                                                                       |
+| 0     | [Catfish](/docs/resources/individual/catfish)                           | 10  | 50    | —                                                                                                                                       |
+| 0     | [Chub](/docs/resources/individual/chub)                                 | 10  | 50    | —                                                                                                                                       |
+| 0     | [Salmon](/docs/resources/individual/salmon)                             | 10  | 50    | [Sashimi](/docs/items/individual/sashimi), [Grey Fish](/docs/items/individual/grey_fish), [Blue Fish](/docs/items/individual/blue_fish) |
+| 0     | [Shrimp Bait](/docs/resources/individual/shrimp_bait)                   | 10  | 50    | —                                                                                                                                       |
+| 0     | [Tilapia](/docs/resources/individual/tilapia)                           | 10  | 50    | [Fish Soup](#)                                                                                                                          |
+| 0     | [Sardine](/docs/resources/individual/sardine)                           | —   | —     | [Sardine Bait](/docs/resources/individual/sardine_bait)                                                                                 |
+| 15    | [Red Drum](/docs/resources/individual/red_drum)                         | —   | —     | —                                                                                                                                       |
+| 15    | [Rainbow Trout](/docs/resources/individual/rainbow_trout)               | 20  | 75    | —                                                                                                                                       |
+| 15    | [Sardine Bait](/docs/resources/individual/sardine_bait)                 | 20  | 75    | —                                                                                                                                       |
+| 15    | [Beige Snapper](/docs/resources/individual/beige_snapper)               | 20  | 75    | —                                                                                                                                       |
+| 30    | [Crab](/docs/resources/individual/crab)                                 | —   | —     | [Cooked Crab](/docs/items/individual/cooked_crab)                                                                                       |
+| 30    | [Carp](/docs/resources/individual/carp)                                 | —   | —     | —                                                                                                                                       |
+| 30    | [Grouper](/docs/resources/individual/grouper)                           | —   | —     | —                                                                                                                                       |
+| 45    | [Largemouth Bass](/docs/resources/individual/largemouth_bass)           | —   | —     | —                                                                                                                                       |
+| 45    | [Tiger Trout](/docs/resources/individual/tiger_trout)                   | —   | —     | —                                                                                                                                       |
+| 45    | [Red Rainbowfish](/docs/resources/individual/red_rainbowfish)           | —   | —     | —                                                                                                                                       |
+| 52    | [Rockfish](/docs/resources/individual/rockfish)                         | —   | —     | —                                                                                                                                       |
+| 60    | [Smallmouth Bass](/docs/resources/individual/smallmouth_bass)           | —   | —     | —                                                                                                                                       |
+| 60    | [Squid](/docs/resources/individual/squid)                               | —   | —     | —                                                                                                                                       |
+| 60    | [Woodskip](/docs/resources/individual/woodskip)                         | —   | —     | —                                                                                                                                       |
+| 60    | [Chattahoochee Bass](/docs/resources/individual/chattahoochee_bass)     | —   | —     | —                                                                                                                                       |
+| 60    | [Lobster](/docs/resources/individual/lobster)                           | —   | —     | [Cooked Lobster](/docs/items/individual/cooked_lobster)                                                                                 |
+| 75    | [Shad](/docs/resources/individual/shad)                                 | —   | —     | —                                                                                                                                       |
+| 75    | [Pufferfish](/docs/resources/individual/pufferfish)                     | —   | —     | [Puff Bait](/docs/resources/individual/puff_bait)                                                                                       |
+| 75    | [Stingray](/docs/resources/individual/stingray)                         | —   | —     | —                                                                                                                                       |
+| 75    | [Lingcod](/docs/resources/individual/lingcod)                           | —   | —     | —                                                                                                                                       |
+| 82    | [Swordfish](/docs/resources/individual/swordfish)                       | —   | —     | —                                                                                                                                       |
+| 82    | [Scorpion Carp](/docs/resources/individual/scorpion_carp)               | —   | —     | —                                                                                                                                       |
+| 82    | [Peach Jellyfish](/docs/resources/individual/peach_jellyfish)           | —   | —     | [Peach Bait](/docs/resources/individual/peach_bait)                                                                                     |
+| 90    | [Speckled Cycloptopus](/docs/resources/individual/speckled_cycloptopus) | —   | —     | —                                                                                                                                       |
+| 90    | [Green Sunfish](/docs/resources/individual/green_sunfish)               | —   | —     | —                                                                                                                                       |
+| 90    | [Sea Snake](/docs/resources/individual/sea_snake)                       | —   | —     | —                                                                                                                                       |
+| 90    | [Orb Octopus](/docs/resources/individual/orb_octopus)                   | —   | —     | —                                                                                                                                       |
+| 90    | [Eldritch Bass](/docs/resources/individual/eldritch_bass)               | —   | —     | —                                                                                                                                       |
 
 ## Training Areas
 


### PR DESCRIPTION
## 📝 Summary

Brief description of what this PR does:
Updated resource documentation to properly distinguish between raw resources (Gathering) and processed materials (Crafting), and added missing gathering statistics for some fish.

- [ ] New content addition
- [x] Content update/correction
- [ ] Bug fix
- [x] Documentation improvement
- [ ] Other: ___

## 🎯 What changed?

Describe the changes you made:
- Updated 99+ individual resource files to use "Gathering" instead of "Crafting" for raw resources that don't require materials
- Raw resources (ores, logs, fruits, vegetables, mushrooms, animals, fish, etc.) now properly show "Gathering"
- Processed materials (bars, planks, toolheads, refined gems) remain as "Crafting"
- Added gathering statistics for fish: Salmon, Chub, Catfish, Shrimp Bait, Rainbow Trout, Sardine Bait, Tilapia, and Beige Snapper
- Updated fishing.mdx skill page with correct XP/Steps values and new fish entries
- Maintains clear distinction between gathered vs crafted resources throughout the wiki

## 📖 Related Issues

- Fixes #(issue number)
- Related to #(issue number)

## ✅ Checklist

Before submitting this PR, please make sure:

- [x] I have read the [contribution guidelines](CONTRIBUTING.md)
- [x] My content follows the wiki's style and formatting conventions
- [x] I have tested that my changes render correctly
- [x] I have checked for spelling and grammatical errors
- [x] My changes are accurate and well-sourced
- [x] I have added appropriate metadata (frontmatter) if creating new pages

## 🔍 Type of content

- [x] Game mechanics documentation
- [x] Item/resource information
- [ ] Location/map content
- [x] Skill guides
- [ ] Character information
- [x] Bug fixes or corrections

## 📸 Screenshots (if applicable)

N/A

## 🤝 Community Impact

How will this help other players?
This update provides players with accurate information about how to obtain resources in the game. Players will now clearly understand which items are gathered directly from skills (Fishing, Foraging, Mining, Logging, Hunting) versus which items need to be crafted using other materials. The added fish gathering statistics give players concrete information about XP gains, steps required, and level requirements for fishing progression.

---

Thank you for contributing to the Stepcraft Wiki! 🎮