### PR TITLE
Fix mobile zoom issue on search.

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -183,6 +183,21 @@ table img {
   margin: 0 !important;
 }
 
+/* Prevent iOS Safari from zooming in on input fields */
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+  input[type="search"],
+  input[type="text"],
+  input[type="email"],
+  input[type="password"],
+  input[type="tel"],
+  input[type="url"],
+  input[type="number"],
+  textarea,
+  select {
+    font-size: 16px !important;
+  }
+}
+
 .prose ul > li::marker {
   color: hsl(0, 0%, 29%);
 }


### PR DESCRIPTION
## 📝 Summary

Brief description of what this PR does:

- [ ] New content addition
- [ ] Content update/correction
- [x] Bug fix
- [ ] Documentation improvement
- [ ] Other: ___

## 🎯 What changed?

Fixed iOS Safari automatically zooming in when users tap on the search input field. Added CSS media query targeting WebKit browsers to enforce a minimum 16px font size on all input fields, preventing the unwanted zoom behavior that was disrupting the mobile user experience.

## 📖 Related Issues

N/A

## ✅ Checklist

Before submitting this PR, please make sure:

- [x] I have read the [contribution guidelines](CONTRIBUTING.md)
- [x] My content follows the wiki's style and formatting conventions
- [x] I have tested that my changes render correctly
- [ ] I have checked for spelling and grammatical errors
- [x] My changes are accurate and well-sourced
- [x] I have added appropriate metadata (frontmatter) if creating new pages

## 🔍 Type of content

- [ ] Game mechanics documentation
- [ ] Item/resource information
- [ ] Location/map content
- [ ] Skill guides
- [ ] Character information
- [x] Bug fixes or corrections

## 📸 Screenshots (if applicable)

N/A

## 🤝 Community Impact

This fix significantly improves the mobile user experience for iOS users by preventing the annoying auto-zoom behavior when searching the wiki. Users can now search seamlessly without the page jumping around, making the wiki much more accessible and user-friendly on mobile devices.

---

Thank you for contributing to the Stepcraft Wiki! 🎮