### PR TITLE
Fix edit page link for individual items.

### DIFF
--- a/components/navigation/feedback.tsx
+++ b/components/navigation/feedback.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link"
 import { useEffect, useState } from "react"
 import { GitHubLink } from "@/settings/navigation"
-import { LuArrowUpRight, LuGitBranch, LuMessageSquare, LuPenTool } from "react-icons/lu"
+import { LuArrowUpRight, LuMessageSquare, LuPenTool } from "react-icons/lu"
 
 import { cn } from "@/lib/utils"
 
@@ -24,13 +24,18 @@ export default function RightSideBar({ slug, title }: SideBarEdit) {
   // Enhanced GitHub URLs with better templates
   const feedbackUrl = `${GitHubLink.href}/issues/new?title=Feedback%20for%20"${encodeURIComponent(title)}"&labels=feedback&body=Page:%20${encodeURIComponent(currentUrl)}`
   
-  // Handle different file structures
-  const editUrl = `${GitHubLink.href}/edit/main/contents/docs/${slug.endsWith('.mdx') ? slug : `${slug}.mdx`}`
-  
-  // Alternative: edit the index.mdx if it's a directory
-  const editIndexUrl = `${GitHubLink.href}/edit/main/contents/docs/${slug}/index.mdx`
-  
-  const contributeUrl = `${GitHubLink.href}/fork`
+  // Generate edit URL with proper fallback logic to match getDocument behavior
+  // Individual pages are direct .mdx files (e.g., items/individual/blue_shield.mdx)
+  // Category/overview pages use index.mdx (e.g., items/index.mdx)
+  const editUrl = (() => {
+    // Check if this is an individual item page (contains '/individual/')
+    if (slug.includes('/individual/')) {
+      return `${GitHubLink.href}/edit/main/contents/docs/${slug}.mdx`
+    }
+    
+    // Category/overview pages use index.mdx
+    return `${GitHubLink.href}/edit/main/contents/docs/${slug}/index.mdx`
+  })()
 
   return (
     <div className="flex flex-col gap-3 pl-2">
@@ -50,7 +55,7 @@ export default function RightSideBar({ slug, title }: SideBarEdit) {
         </Link>
         
         <Link
-          href={editIndexUrl}
+          href={editUrl}
           target="_blank"
           rel="noopener noreferrer"
           className={cn(


### PR DESCRIPTION
## 📝 Summary

Fixed the edit page button that was generating incorrect GitHub URLs for individual item pages, causing 404 errors when users tried to contribute to the wiki.

- [x] Bug fix
- [ ] New content addition
- [ ] Content update/correction
- [ ] Documentation improvement
- [ ] Other: ___

## 🎯 What changed?

**Problem:** The edit button was hardcoded to always use `/index.mdx` paths (e.g., `items/individual/blue_shield/index.mdx`), but individual pages are stored as direct `.mdx` files (e.g., `items/individual/blue_shield.mdx`).

**Solution:** 
- Updated `components/navigation/feedback.tsx` to implement smart path generation
- Individual pages (containing `/individual/`) now use direct `.mdx` format
- Category/overview pages continue to use `/index.mdx` format
- Added proper logic to handle both file structure patterns

**Impact:** Users can now successfully edit individual item, skill, resource, and location pages without encountering 404 errors.

## 📖 Related Issues

- Fixes community contribution barriers caused by broken edit links
- Improves user experience for wiki contributors

## ✅ Checklist

Before submitting this PR, please make sure:

- [x] I have read the [contribution guidelines](CONTRIBUTING.md)
- [x] My content follows the wiki's style and formatting conventions
- [x] I have tested that my changes render correctly
- [x] I have checked for spelling and grammatical errors
- [x] My changes are accurate and well-sourced
- [x] I have added appropriate metadata (frontmatter) if creating new pages

## 🔍 Type of content

- [ ] Game mechanics documentation
- [ ] Item/resource information
- [ ] Location/map content
- [ ] Skill guides
- [ ] Character information
- [x] Bug fixes or corrections

## 🧪 Testing

**Verified edit URLs work correctly for:**
- Individual items: `items/individual/blue_shield` → `items/individual/blue_shield.mdx`
- Category pages: `items` → `items/index.mdx`
- Individual skills: `skills/individual/farming` → `skills/individual/farming.mdx`
- Other page types with proper file path detection

## 🤝 Community Impact

This fix removes a major barrier for community contributions by ensuring the "Edit Page" button works correctly for all page types. Contributors will no longer encounter 404 errors when trying to edit individual item, skill, resource, or location pages, making it much easier for the community to help improve and maintain the wiki.

---

Thank you for contributing to the Stepcraft Wiki! 🎮