### PR TITLE
Add red mushroom back to combat page.

### DIFF
--- a/contents/docs/skills/individual/combat.mdx
+++ b/contents/docs/skills/individual/combat.mdx
@@ -29,9 +29,10 @@ lastVerified: 2025-08-16
 | Level | Enemy | XP | Steps | Drops (per kill) |
 |-------|-------|-----------------|-------------------|------------------|
 | 0 | [Green Slime](/docs/enemies/individual/green_slime) | 10 | 50 | 1x [Slime](/docs/resources/individual/slime), 1x [Moonstone Tablet](/docs/items/individual/moonstone_tablet) (15%) |
-| 15 | [Brown Mushroom](/docs/enemies/individual/brown_mushroom) | 20 | 75 | 1x [Brown Mushroom](/docs/resources/individual/brown_mushroom), 1x [Fly Agaric](/docs/resources/individual/fly_agaric) (10%), 1x [Fang](/docs/items/individual/fang) (60%) |
+| 7 | [Red Mushroom](/docs/enemies/individual/red_mushroom) | 15 | 60 | 1x [Fly Agaric](/docs/resources/individual/fly_agaric), 1x [Fang](/docs/resources/individual/fang) (50%) |
+| 15 | [Brown Mushroom](/docs/enemies/individual/brown_mushroom) | 20 | 75 | 1x [Brown Mushroom](/docs/resources/individual/brown_mushroom), 1x [Fly Agaric](/docs/resources/individual/fly_agaric) (10%), 1x [Fang](/docs/resources/individual/fang) (60%) |
 | 22 | [Ghost Slime](/docs/enemies/individual/ghost_slime) | 30 | 85 | 3x [Slime](/docs/resources/individual/slime) |
-| 22 | [Purple Mushroom](/docs/enemies/individual/purple_mushroom) | 30 | 85 | 1x [Violet Webcap](/docs/resources/individual/violet_webcap), 1x [Chanterelle](/docs/resources/individual/chanterelle) (10%), 1x [Fang](/docs/items/individual/fang) (70%) |
+| 22 | [Purple Mushroom](/docs/enemies/individual/purple_mushroom) | 30 | 85 | 1x [Violet Webcap](/docs/resources/individual/violet_webcap), 1x [Chanterelle](/docs/resources/individual/chanterelle) (10%), 1x [Fang](/docs/resources/individual/fang) (70%) |
 | 30 | [Common Rat](/docs/enemies/individual/common_rat) | 40 | 100 | 1x [Egg](/docs/resources/individual/egg) |
 | 30 | [Stick Ent](/docs/enemies/individual/stick_ent) | 40 | 150 | 10x [Sticks](/docs/resources/individual/sticks) |
 | — | [Flame Slime](/docs/enemies/individual/flame_slime) | — | — | — |


### PR DESCRIPTION
## 📝 Summary

Brief description of what this PR does:

- [x] New content addition
- [ ] Content update/correction
- [ ] Bug fix
- [ ] Documentation improvement
- [ ] Other: ___

## 🎯 What changed?

Added Red Mushroom enemy to the Combat skill's enemies table:

- **Red Mushroom** (Level 7): 15 XP, 60 steps per combat action
- **Drops**: 1x Fly Agaric (guaranteed), 1x Fang (50% chance)
- Positioned correctly in level order between Green Slime (Level 0) and Brown Mushroom (Level 15)

## 📖 Related Issues

- Fixes #(issue number)
- Related to #(issue number)

## ✅ Checklist

Before submitting this PR, please make sure:

- [x] I have read the [contribution guidelines](CONTRIBUTING.md)
- [x] My content follows the wiki's style and formatting conventions
- [x] I have tested that my changes render correctly
- [x] I have checked for spelling and grammatical errors
- [x] My changes are accurate and well-sourced
- [ ] I have added appropriate metadata (frontmatter) if creating new pages

## 🔍 Type of content

- [x] Game mechanics documentation
- [ ] Item/resource information
- [ ] Location/map content
- [ ] Skill guides
- [ ] Character information
- [ ] Bug fixes or corrections

## 📸 Screenshots (if applicable)

N/A

## 🤝 Community Impact

This addition helps players understand the complete progression of combat enemies available at each level, providing them with accurate information about XP rewards, step requirements, and drop rates for the Red Mushroom enemy.

---

Thank you for contributing to the Stepcraft Wiki! 🎮