### PR TITLE
Fix issue with sitemap base urls being wrong.

### DIFF
--- a/settings/documents.ts
+++ b/settings/documents.ts
@@ -3,22 +3,22 @@ import { Paths } from "@/lib/pageroutes"
 export const Documents: Paths[] = [
   {
     title: "Getting Started",
-    href: "/getting-started",
+    href: "/docs/getting-started",
   },
   {
     title: "Disclaimer",
-    href: "/disclaimer",
+    href: "/docs/disclaimer",
   },
   {
     title: "How to Contribute",
-    href: "/how-to-contribute",
+    href: "/docs/how-to-contribute",
   },
   {
     spacer: true
   },
   {
     title: "Skills",
-    href: "/skills",
+    href: "/docs/skills",
     items: [
       {
         title: "Agility",
@@ -84,7 +84,7 @@ export const Documents: Paths[] = [
   },
   {
     title: "Items & Equipment",
-    href: "/items",
+    href: "/docs/items",
     items: [      
       {
         title: "Tools",
@@ -122,7 +122,7 @@ export const Documents: Paths[] = [
   },
   {
     title: "Resources & Materials",
-    href: "/resources",
+    href: "/docs/resources",
     items: [
       {
         title: "Tool Parts",
@@ -180,7 +180,7 @@ export const Documents: Paths[] = [
   },
   {
     title: "World & Locations",
-    href: "/map",
+    href: "/docs/map",
     items: [      
       {
         title: "Overview",
@@ -218,10 +218,10 @@ export const Documents: Paths[] = [
   },
   {
     title: "Enemies",
-    href: "/enemies",
+    href: "/docs/enemies",
   },
   {
     title: "Quests",
-    href: "/quests",
+    href: "/docs/quests",
   },
 ]

--- a/settings/settings.ts
+++ b/settings/settings.ts
@@ -1,4 +1,4 @@
-export const url = "https://stepcraft-wiki.vercel.app"
+export const url = "https://wiki.stepcraft.app"
 export const siteicon = "/assets/icon.png"
 
 export const gtm = "G-9RLC2XGHKE"


### PR DESCRIPTION
## 📝 Summary

Brief description of what this PR does:

Critical SEO fixes to resolve incorrect base URL and sitemap generation that was preventing Google from indexing the wiki content.

- [ ] New content addition
- [ ] Content update/correction
- [x] Bug fix
- [ ] Documentation improvement
- [ ] Other: ___

## 🎯 What changed?

**Fixed Critical SEO Issues:**

1. **Corrected Base URL Configuration**
   - Changed from `https://stepcraft-wiki.vercel.app` to `https://wiki.stepcraft.app` in `/settings/settings.ts`
   - This fixes robots.txt and sitemap.xml generation

2. **Fixed Sitemap URL Structure** 
   - Updated all document routes in `/settings/documents.ts` to include proper `/docs/` prefix
   - URLs now correctly point to `/docs/getting-started`, `/docs/resources`, etc. instead of missing the `/docs/` path

**Impact:** 
- robots.txt now correctly references `https://wiki.stepcraft.app/sitemap.xml`
- Sitemap now contains proper URLs like `https://wiki.stepcraft.app/docs/resources/individual/copper_ore`
- Google can now properly crawl and index all wiki content

## 📖 Related Issues

- Fixes search engine indexing issues preventing "stepcraft copper ore" and similar queries from finding wiki content
- Resolves sitemap/robots.txt URL mismatches

## ✅ Checklist

Before submitting this PR, please make sure:

- [x] I have read the [contribution guidelines](CONTRIBUTING.md)
- [x] My content follows the wiki's style and formatting conventions
- [x] I have tested that my changes render correctly
- [x] I have checked for spelling and grammatical errors
- [x] My changes are accurate and well-sourced
- [x] I have added appropriate metadata (frontmatter) if creating new pages

## 🔍 Type of content

- [ ] Game mechanics documentation
- [ ] Item/resource information
- [ ] Location/map content
- [ ] Skill guides
- [ ] Character information
- [x] Bug fixes or corrections

## 📸 Screenshots (if applicable)

None

## 🤝 Community Impact

This fix resolves the primary reason why the Stepcraft Wiki wasn't appearing in Google search results. Players searching for "stepcraft copper ore" or any other wiki content should be able to find the relevant pages (after Google reindexes). This is a critical infrastructure fix that enables the wiki to fulfill its purpose of helping the Stepcraft community.

**Expected Results:**
- Wiki pages will start appearing in Google search results within 1-2 weeks
- Improved discoverability for all game content and guides
- Proper SEO foundation for future content growth

---

Thank you for contributing to the Stepcraft Wiki! 🎮